### PR TITLE
Add initial GitHub Pages site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # solve-coagulate.github.io
-My github pages
+
+This repository hosts my GitHub Pages site. The main page lives in `index.html` and is served directly from the main branch.
+
+To preview the site locally, simply open `index.html` in a browser. Once pushed to GitHub with Pages enabled (under **Settings -> Pages**), it will be available at:
+
+```
+https://solve-coagulate.github.io/
+```
+
+Feel free to check back for updates!

--- a/index.html
+++ b/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>solve-coagulate.github.io</title>
+  <style>
+    body { font-family: Arial, sans-serif; max-width: 800px; margin: 2em auto; line-height: 1.6; }
+    header { text-align: center; margin-bottom: 2em; }
+    footer { text-align: center; margin-top: 2em; font-size: 0.9em; color: #666; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Welcome to Solve-Coagulate</h1>
+    <p>This is my GitHub Pages site.</p>
+  </header>
+
+  <main>
+    <p>Here I'll share projects, notes, and anything else I find interesting. Stay tuned!</p>
+  </main>
+
+  <footer>
+    <p>Hosted with <a href="https://pages.github.com/">GitHub Pages</a>.</p>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a simple `index.html` page for GitHub Pages
- expand README with usage instructions

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6841ee70e8f4832a9c8a890898e2523a