### PR TITLE
Add microeconomics subpages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,4 +2,5 @@
 
 - Keep this AGENTS.md file up to date.
 - Record anything surprising or noteworthy for future agents.
+- Microeconomics topics have individual HTML pages linked from the index (2025-06).
 

--- a/docs/microeconomics/agents.html
+++ b/docs/microeconomics/agents.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Economic Agents and Utility</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    body { font-family: Arial, sans-serif; margin: 0; padding: 20px; background: #f9f9f9; }
+    header { background: #333; color: white; padding: 10px 20px; }
+    main { max-width: 800px; margin: auto; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Economic Agents and Utility</h1>
+  </header>
+  <main>
+    <p>Individuals, firms, and governments act as agents in the economy. Each seeks to maximize some form of utility given their constraints.</p>
+    <p>Utility captures satisfaction or benefit, and it helps explain choices such as consumption, production, and even regulation when governments balance social welfare concerns.</p>
+    <p><a href="index.html">Back to Guide</a></p>
+    <p><a href="../index.html">Home</a></p>
+  </main>
+</body>
+</html>

--- a/docs/microeconomics/assumptions.html
+++ b/docs/microeconomics/assumptions.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Assumptions of the Free Market</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    body { font-family: Arial, sans-serif; margin: 0; padding: 20px; background: #f9f9f9; }
+    header { background: #333; color: white; padding: 10px 20px; }
+    main { max-width: 800px; margin: auto; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Assumptions of the Free Market</h1>
+  </header>
+  <main>
+    <p>Classical models rely on assumptions such as perfect competition, complete information, and the absence of externalities or public goods.</p>
+    <p>These assumptions allow markets to allocate resources efficiently, though in reality they seldom hold perfectly. Recognizing departures from these ideals helps economists explain market failures.</p>
+    <p><a href="index.html">Back to Guide</a></p>
+    <p><a href="../index.html">Home</a></p>
+  </main>
+</body>
+</html>

--- a/docs/microeconomics/failures.html
+++ b/docs/microeconomics/failures.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Market Failures</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    body { font-family: Arial, sans-serif; margin: 0; padding: 20px; background: #f9f9f9; }
+    header { background: #333; color: white; padding: 10px 20px; }
+    main { max-width: 800px; margin: auto; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Market Failures and Corrections</h1>
+  </header>
+  <main>
+    <p>Markets may fail to deliver efficient outcomes when externalities, market power, or information problems are present.</p>
+    <p>Policy tools such as taxes, subsidies, or regulation are often used to correct these failures and move the economy closer to efficiency.</p>
+    <p><a href="index.html">Back to Guide</a></p>
+    <p><a href="../index.html">Home</a></p>
+  </main>
+</body>
+</html>

--- a/docs/microeconomics/fft.html
+++ b/docs/microeconomics/fft.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>First Fundamental Theorem</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    body { font-family: Arial, sans-serif; margin: 0; padding: 20px; background: #f9f9f9; }
+    header { background: #333; color: white; padding: 10px 20px; }
+    main { max-width: 800px; margin: auto; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>First Fundamental Theorem of Welfare Economics</h1>
+  </header>
+  <main>
+    <p>The first fundamental theorem states that competitive markets produce Pareto efficient outcomes if the classical assumptions hold.</p>
+    <p>This result underpins the idea that decentralized markets can achieve efficient allocations without central planning.</p>
+    <p><a href="index.html">Back to Guide</a></p>
+    <p><a href="../index.html">Home</a></p>
+  </main>
+</body>
+</html>

--- a/docs/microeconomics/index.html
+++ b/docs/microeconomics/index.html
@@ -35,41 +35,49 @@
     <section id="what">
       <h2>What is Economics?</h2>
       <p>Economics studies how people allocate scarce resources and make choices. Microeconomics focuses on individual agents such as consumers and firms.</p>
+      <p><a href="what.html">Learn more</a></p>
     </section>
 
     <section id="positive">
       <h2>Positive and Normative Economics</h2>
       <p>Positive economics describes how things are and relies on testable statements. Normative economics involves value judgments about how things should be.</p>
+      <p><a href="positive.html">Learn more</a></p>
     </section>
 
     <section id="agents">
       <h2>Economic Agents and Utility</h2>
       <p>Agents—consumers, firms, and governments—seek to maximize utility subject to constraints. Utility represents satisfaction or benefit.</p>
+      <p><a href="agents.html">Learn more</a></p>
     </section>
 
     <section id="assumptions">
       <h2>Assumptions of the Free Market</h2>
       <p>Classical models assume perfect competition, perfect information, and no externalities. These conditions ensure that markets allocate resources efficiently.</p>
+      <p><a href="assumptions.html">Learn more</a></p>
     </section>
 
     <section id="fft">
       <h2>First Fundamental Theorem of Welfare Economics</h2>
       <p>When the free market assumptions hold, competitive markets lead to Pareto efficient outcomes without the need for central planning.</p>
+      <p><a href="fft.html">Learn more</a></p>
     </section>
 
     <section id="failures">
       <h2>Market Failures and Corrections</h2>
       <p>Real-world markets often deviate from the ideal. Externalities, monopolies, and information gaps can require policy interventions such as taxes, regulation, or subsidies.</p>
+      <p><a href="failures.html">Learn more</a></p>
     </section>
 
     <section id="sft">
       <h2>Second Fundamental Theorem</h2>
       <p>The second theorem states that any Pareto efficient allocation can be achieved by redistributing endowments and then allowing markets to operate. Universal basic income is one example of how transfers might support equity while preserving market efficiency.</p>
+      <p><a href="sft.html">Learn more</a></p>
     </section>
 
     <section id="other">
       <h2>Other Key Concepts</h2>
       <p>This guide also covers <a href="supply.html">supply</a> and <a href="demand.html">demand</a>. Review the <a href="quiz.html">quiz</a> to test your knowledge.</p>
+      <p><a href="other.html">Learn more</a></p>
     </section>
 
   </main>

--- a/docs/microeconomics/other.html
+++ b/docs/microeconomics/other.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Other Key Concepts</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    body { font-family: Arial, sans-serif; margin: 0; padding: 20px; background: #f9f9f9; }
+    header { background: #333; color: white; padding: 10px 20px; }
+    main { max-width: 800px; margin: auto; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Other Key Concepts</h1>
+  </header>
+  <main>
+    <p>Microeconomics also examines how supply interacts with demand to create market equilibrium. Elasticity, consumer surplus, and producer surplus are important measures of market performance.</p>
+    <p>For deeper discussions of supply and demand, see the dedicated pages linked below.</p>
+    <p><a href="supply.html">Supply</a> | <a href="demand.html">Demand</a></p>
+    <p><a href="index.html">Back to Guide</a></p>
+    <p><a href="../index.html">Home</a></p>
+  </main>
+</body>
+</html>

--- a/docs/microeconomics/positive.html
+++ b/docs/microeconomics/positive.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Positive vs. Normative Economics</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    body { font-family: Arial, sans-serif; margin: 0; padding: 20px; background: #f9f9f9; }
+    header { background: #333; color: white; padding: 10px 20px; }
+    main { max-width: 800px; margin: auto; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Positive and Normative Economics</h1>
+  </header>
+  <main>
+    <p>Positive economics seeks to describe and predict economic behavior using testable statements. These claims can be confirmed or refuted with data.</p>
+    <p>Normative economics offers prescriptions about what should happen, often reflecting ethical views or policy goals. Distinguishing the two helps clarify debates about economic policy.</p>
+    <p><a href="index.html">Back to Guide</a></p>
+    <p><a href="../index.html">Home</a></p>
+  </main>
+</body>
+</html>

--- a/docs/microeconomics/sft.html
+++ b/docs/microeconomics/sft.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Second Fundamental Theorem</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    body { font-family: Arial, sans-serif; margin: 0; padding: 20px; background: #f9f9f9; }
+    header { background: #333; color: white; padding: 10px 20px; }
+    main { max-width: 800px; margin: auto; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Second Fundamental Theorem of Welfare Economics</h1>
+  </header>
+  <main>
+    <p>The second theorem indicates that any Pareto efficient allocation can be reached through appropriate redistribution followed by free exchange.</p>
+    <p>It separates equity and efficiency concerns, suggesting that policy makers can use transfers to achieve fairness without distorting markets.</p>
+    <p><a href="index.html">Back to Guide</a></p>
+    <p><a href="../index.html">Home</a></p>
+  </main>
+</body>
+</html>

--- a/docs/microeconomics/what.html
+++ b/docs/microeconomics/what.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>What is Economics?</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    body { font-family: Arial, sans-serif; margin: 0; padding: 20px; background: #f9f9f9; }
+    header { background: #333; color: white; padding: 10px 20px; }
+    main { max-width: 800px; margin: auto; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>What is Economics?</h1>
+  </header>
+  <main>
+    <p>Economics studies how people and societies allocate scarce resources to satisfy unlimited wants. Microeconomics focuses on the decisions of individual consumers and firms.</p>
+    <p>This broader view highlights trade-offs, opportunity costs, and how incentives drive behavior in markets.</p>
+    <p><a href="index.html">Back to Guide</a></p>
+    <p><a href="../index.html">Home</a></p>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- split microeconomics overview into individual topic pages
- link new pages from each section in the microeconomics guide
- document site changes in AGENTS.md

## Testing
- `echo "No test suite present"`

------
https://chatgpt.com/codex/tasks/task_e_6845a0151ec0832aac376a1f81df9d19