### PR TITLE
Add diet tracker tests to app folder

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,4 +4,6 @@
 - Record anything surprising or noteworthy for future agents.
 - Microeconomics topics have individual HTML pages linked from the index (2025-06).
 - The `docs/webapps/` folder holds small standalone apps. `diet-tracker/index.html` is linked from the site index (2025-06).
+- Basic unit tests for the diet tracker live under
+  `docs/webapps/diet-tracker/tests/` and can be run with `npm test` (2025-07).
 

--- a/docs/webapps/diet-tracker/AGENTS.md
+++ b/docs/webapps/diet-tracker/AGENTS.md
@@ -1,3 +1,4 @@
 # Diet Tracker Folder
 - Keep `index.html` self-contained so it can run as a standalone app.
 - Update `use-cases.md` when major features change.
+- Unit tests for this app live in the `tests/` subfolder and run with `npm test`.

--- a/docs/webapps/diet-tracker/tests/computeTotals.test.js
+++ b/docs/webapps/diet-tracker/tests/computeTotals.test.js
@@ -1,0 +1,22 @@
+const assert = require('assert');
+
+const computeTotals = entries => entries.reduce((acc, e) => ({
+  kj: acc.kj + e.kj,
+  protein: acc.protein + e.protein,
+  carbs: acc.carbs + e.carbs,
+  fat: acc.fat + e.fat
+}), {kj:0, protein:0, carbs:0, fat:0});
+
+// tests
+assert.deepStrictEqual(computeTotals([]), {kj:0, protein:0, carbs:0, fat:0}, 'empty array');
+assert.deepStrictEqual(computeTotals([{kj:100,protein:10,carbs:20,fat:5}]), {kj:100, protein:10, carbs:20, fat:5}, 'single entry');
+assert.deepStrictEqual(
+  computeTotals([
+    {kj:100,protein:10,carbs:20,fat:5},
+    {kj:200,protein:20,carbs:40,fat:10}
+  ]),
+  {kj:300, protein:30, carbs:60, fat:15},
+  'multiple entries'
+);
+
+console.log('computeTotals tests passed');

--- a/docs/webapps/diet-tracker/tests/mru.test.js
+++ b/docs/webapps/diet-tracker/tests/mru.test.js
@@ -1,0 +1,14 @@
+const assert = require('assert');
+
+const updateMru = (list, name) => {
+  const newList = list.filter(n => n !== name);
+  newList.unshift(name);
+  return newList;
+};
+
+// tests
+assert.deepStrictEqual(updateMru([], 'apple'), ['apple']);
+assert.deepStrictEqual(updateMru(['apple','banana'], 'banana'), ['banana','apple']);
+assert.deepStrictEqual(updateMru(['apple','banana'], 'apple'), ['apple','banana']);
+
+console.log('MRU tests passed');

--- a/docs/webapps/diet-tracker/tests/persist.test.js
+++ b/docs/webapps/diet-tracker/tests/persist.test.js
@@ -1,0 +1,26 @@
+const assert = require('assert');
+
+// simple localStorage stub
+const fakeLocalStorage = (() => {
+  let data = {};
+  return {
+    setItem: (k, v) => { data[k] = v; },
+    getItem: k => data[k],
+    reset: () => { data = {}; }
+  };
+})();
+
+const persist = (myappdata, {foodDB, history, mruFoods}) => {
+  myappdata['dietTracker'] = { foodDB, history, mruFoods };
+  fakeLocalStorage.setItem('myappdata', JSON.stringify(myappdata));
+};
+
+const myappdata = {};
+const saved = { foodDB:{apple:{kj:100}}, history:{}, mruFoods:['apple'] };
+
+persist(myappdata, saved);
+const stored = JSON.parse(fakeLocalStorage.getItem('myappdata'));
+assert.deepStrictEqual(stored.dietTracker.foodDB, saved.foodDB);
+assert.deepStrictEqual(stored.dietTracker.mruFoods, ['apple']);
+
+console.log('persist tests passed');

--- a/docs/webapps/diet-tracker/tests/run.js
+++ b/docs/webapps/diet-tracker/tests/run.js
@@ -1,0 +1,4 @@
+require('./computeTotals.test');
+require('./mru.test');
+require('./persist.test');
+console.log('All tests passed');

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "solve-coagulate.github.io",
+  "version": "1.0.0",
+  "description": "This repository hosts my GitHub Pages site. All of the HTML lives in the `docs/` folder so the main branch stays tidy.",
+  "main": "index.js",
+  "directories": {
+    "doc": "docs"
+  },
+  "scripts": {
+    "test": "node docs/webapps/diet-tracker/tests/run.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}


### PR DESCRIPTION
## Summary
- move diet tracker tests under the webapp directory
- update AGENTS guidance for new test location
- update npm script to run tests from new folder

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686cef72f520832aa9738517fd6275ff