### PR TITLE
Improve diet tracker tests

### DIFF
--- a/docs/webapps/diet-tracker/index.html
+++ b/docs/webapps/diet-tracker/index.html
@@ -116,13 +116,23 @@
   let diaryEntries = [];
   let totals = {kj:0, protein:0, carbs:0, fat:0};
 
+  /* START EXPORTS */
   const computeTotals = entries => entries.reduce((acc,e)=>({kj:acc.kj+e.kj,protein:acc.protein+e.protein,carbs:acc.carbs+e.carbs,fat:acc.fat+e.fat}),{kj:0,protein:0,carbs:0,fat:0});
+
+  const updateMru = (list, name) => {
+    const newList = list.filter(n => n !== name);
+    newList.unshift(name);
+    return newList;
+  };
 
   const persist = () => {
     // include MRU list in storage
     myappdata[APP_KEY] = {foodDB, history, mruFoods: saved.mruFoods};
     localStorage.setItem('myappdata', JSON.stringify(myappdata));
   };
+
+  if (typeof window !== 'undefined') window.DietTrackerExports = {computeTotals, updateMru, persist};
+  /* END EXPORTS */
 
   const loadDiary = (date) => {
     const data = history[date];
@@ -250,8 +260,7 @@
     $('diaryFood').value = '';
     $('amount').value = '';
     // update MRU list
-    saved.mruFoods = saved.mruFoods.filter(n => n !== name);
-    saved.mruFoods.unshift(name);
+    saved.mruFoods = updateMru(saved.mruFoods, name);
     // persist MRU update
     persist();
   });

--- a/docs/webapps/diet-tracker/tests/computeTotals.test.js
+++ b/docs/webapps/diet-tracker/tests/computeTotals.test.js
@@ -1,20 +1,18 @@
 const assert = require('assert');
 
-const computeTotals = entries => entries.reduce((acc, e) => ({
-  kj: acc.kj + e.kj,
-  protein: acc.protein + e.protein,
-  carbs: acc.carbs + e.carbs,
-  fat: acc.fat + e.fat
-}), {kj:0, protein:0, carbs:0, fat:0});
+const loadExports = require('./helpers');
+const { computeTotals } = loadExports();
+
+const toPlain = obj => JSON.parse(JSON.stringify(obj));
 
 // tests
-assert.deepStrictEqual(computeTotals([]), {kj:0, protein:0, carbs:0, fat:0}, 'empty array');
-assert.deepStrictEqual(computeTotals([{kj:100,protein:10,carbs:20,fat:5}]), {kj:100, protein:10, carbs:20, fat:5}, 'single entry');
+assert.deepStrictEqual(toPlain(computeTotals([])), {kj:0, protein:0, carbs:0, fat:0}, 'empty array');
+assert.deepStrictEqual(toPlain(computeTotals([{kj:100,protein:10,carbs:20,fat:5}])), {kj:100, protein:10, carbs:20, fat:5}, 'single entry');
 assert.deepStrictEqual(
-  computeTotals([
+  toPlain(computeTotals([
     {kj:100,protein:10,carbs:20,fat:5},
     {kj:200,protein:20,carbs:40,fat:10}
-  ]),
+  ])),
   {kj:300, protein:30, carbs:60, fat:15},
   'multiple entries'
 );

--- a/docs/webapps/diet-tracker/tests/helpers.js
+++ b/docs/webapps/diet-tracker/tests/helpers.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+module.exports = function loadExports() {
+  const htmlPath = path.join(__dirname, '../index.html');
+  const html = fs.readFileSync(htmlPath, 'utf8');
+  const match = html.match(/\/\* START EXPORTS \*\/[\s\S]*?\/\* END EXPORTS \*\//);
+  if (!match) throw new Error('Export section not found');
+  const code = match[0].replace(/\/\* START EXPORTS \*\//, '').replace(/\/\* END EXPORTS \*\//, '');
+  const context = {
+    localStorage: {
+      _data: {},
+      setItem(k, v) { this._data[k] = v; },
+      getItem(k) { return this._data[k]; }
+    },
+    myappdata: {},
+    APP_KEY: 'dietTracker',
+    foodDB: {},
+    history: {},
+    saved: { mruFoods: [] },
+    module: { exports: {} }
+  };
+  vm.createContext(context);
+  vm.runInContext(code + '\nthis.computeTotals = computeTotals;\nthis.updateMru = updateMru;\nthis.persist = persist;', context);
+  return context;
+};

--- a/docs/webapps/diet-tracker/tests/mru.test.js
+++ b/docs/webapps/diet-tracker/tests/mru.test.js
@@ -1,10 +1,7 @@
 const assert = require('assert');
 
-const updateMru = (list, name) => {
-  const newList = list.filter(n => n !== name);
-  newList.unshift(name);
-  return newList;
-};
+const loadExports = require('./helpers');
+const { updateMru } = loadExports();
 
 // tests
 assert.deepStrictEqual(updateMru([], 'apple'), ['apple']);

--- a/docs/webapps/diet-tracker/tests/persist.test.js
+++ b/docs/webapps/diet-tracker/tests/persist.test.js
@@ -1,26 +1,17 @@
 const assert = require('assert');
 
-// simple localStorage stub
-const fakeLocalStorage = (() => {
-  let data = {};
-  return {
-    setItem: (k, v) => { data[k] = v; },
-    getItem: k => data[k],
-    reset: () => { data = {}; }
-  };
-})();
+const loadExports = require('./helpers');
+const ctx = loadExports();
+const { persist, myappdata, localStorage } = ctx;
 
-const persist = (myappdata, {foodDB, history, mruFoods}) => {
-  myappdata['dietTracker'] = { foodDB, history, mruFoods };
-  fakeLocalStorage.setItem('myappdata', JSON.stringify(myappdata));
-};
+ctx.foodDB = { apple: {kj:100} };
+ctx.history = {};
+ctx.saved.mruFoods = ['apple'];
 
-const myappdata = {};
-const saved = { foodDB:{apple:{kj:100}}, history:{}, mruFoods:['apple'] };
+persist();
 
-persist(myappdata, saved);
-const stored = JSON.parse(fakeLocalStorage.getItem('myappdata'));
-assert.deepStrictEqual(stored.dietTracker.foodDB, saved.foodDB);
+const stored = JSON.parse(localStorage.getItem('myappdata'));
+assert.deepStrictEqual(stored.dietTracker.foodDB, ctx.foodDB);
 assert.deepStrictEqual(stored.dietTracker.mruFoods, ['apple']);
 
 console.log('persist tests passed');


### PR DESCRIPTION
## Summary
- expose helper functions from the Diet Tracker HTML
- update MRU logic to use a new helper
- provide a small loader to pull functions from the HTML for unit tests
- rewrite tests to use the real app code

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686cf92b68b4832aa93ee49f9bd65bfe