### PR TITLE
Refactor diet tracker exports

### DIFF
--- a/docs/webapps/diet-tracker/AGENTS.md
+++ b/docs/webapps/diet-tracker/AGENTS.md
@@ -2,3 +2,4 @@
 - JS and CSS may be split out of `index.html` to aid testing and maintenance. The current files are `app.js` and `style.css` (2025-07).
 - Update `use-cases.md` when major features change.
 - Unit tests for this app live in the `tests/` subfolder and run with `npm test`.
+- Helper functions are exported from `app.js` using `module.exports`; tests require this module directly.

--- a/docs/webapps/diet-tracker/tests/helpers.js
+++ b/docs/webapps/diet-tracker/tests/helpers.js
@@ -1,27 +1,10 @@
-const fs = require('fs');
-const path = require('path');
-const vm = require('vm');
-
 module.exports = function loadExports() {
-  const jsPath = path.join(__dirname, '../app.js');
-  const js = fs.readFileSync(jsPath, 'utf8');
-  const match = js.match(/\/\* START EXPORTS \*\/[\s\S]*?\/\* END EXPORTS \*\//);
-  if (!match) throw new Error('Export section not found');
-  const code = match[0].replace(/\/\* START EXPORTS \*\//, '').replace(/\/\* END EXPORTS \*\//, '');
-  const context = {
-    localStorage: {
-      _data: {},
-      setItem(k, v) { this._data[k] = v; },
-      getItem(k) { return this._data[k]; }
-    },
-    myappdata: {},
-    APP_KEY: 'dietTracker',
-    foodDB: {},
-    history: {},
-    saved: { mruFoods: [] },
-    module: { exports: {} }
+  delete require.cache[require.resolve('../app.js')];
+  global.localStorage = {
+    _data: {},
+    setItem(k, v) { this._data[k] = v; },
+    getItem(k) { return this._data[k]; }
   };
-  vm.createContext(context);
-  vm.runInContext(code + '\nthis.computeTotals = computeTotals;\nthis.updateMru = updateMru;\nthis.persist = persist;\nthis.scaleEntry = scaleEntry;', context);
-  return context;
+  global.myappdata = {};
+  return require('../app.js');
 };

--- a/docs/webapps/diet-tracker/tests/persist.test.js
+++ b/docs/webapps/diet-tracker/tests/persist.test.js
@@ -2,11 +2,11 @@ const assert = require('assert');
 
 const loadExports = require('./helpers');
 const ctx = loadExports();
-const { persist, myappdata, localStorage } = ctx;
+const { persist, myappdata, localStorage, foodDB, history, saved } = ctx;
 
-ctx.foodDB = { apple: {kj:100} };
-ctx.history = {};
-ctx.saved.mruFoods = ['apple'];
+Object.assign(foodDB, { apple: {kj:100} });
+Object.assign(history, {});
+saved.mruFoods = ['apple'];
 
 persist();
 


### PR DESCRIPTION
## Summary
- export diet tracker helpers using `module.exports`
- remove old start/end export tags
- load app helpers directly in tests
- adjust persist test to modify exported objects
- document export approach in `AGENTS.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d523f00c4832a8f1939b27f7bf54a