### PR TITLE
Fix scale for 100g units

### DIFF
--- a/docs/webapps/diet-tracker/app.js
+++ b/docs/webapps/diet-tracker/app.js
@@ -28,8 +28,13 @@ const persist = () => {
 };
 
 const parseUnitNumber = unit => {
-  const nums = String(unit).match(/[0-9]*\.?[0-9]+/g);
-  if (nums && nums.length) return parseFloat(nums[0]);
+  if (unit == null) return 1;
+  const m = String(unit).trim().match(/[0-9.,]+/);
+  if (m) {
+    const cleaned = m[0].replace(/,/g, '');
+    const num = parseFloat(cleaned);
+    if (!isNaN(num)) return num;
+  }
   return 1;
 };
 

--- a/docs/webapps/diet-tracker/tests/scaleEntry.test.js
+++ b/docs/webapps/diet-tracker/tests/scaleEntry.test.js
@@ -10,6 +10,11 @@ assert.deepStrictEqual(
   { kj: 100, protein: 5, carbs: 10, fat: 2.5 },
   'scales by half when amount is half the unit'
 );
+assert.deepStrictEqual(
+  toPlain(scaleEntry(food, 100)),
+  { kj: 200, protein: 10, carbs: 20, fat: 5 },
+  'matches macros when amount equals unit'
+);
 
 const cup = { unit: '1 cup', kj: 120, protein: 6, carbs: 12, fat: 2 };
 assert.deepStrictEqual(
@@ -23,6 +28,13 @@ assert.deepStrictEqual(
   toPlain(scaleEntry(complex, 50)),
   { kj: 10000, protein: 500, carbs: 1000, fat: 250 },
   'uses the first numeric value when unit string contains multiple numbers'
+);
+
+const spaced = { unit: '100 g', kj: 200, protein: 10, carbs: 20, fat: 5 };
+assert.deepStrictEqual(
+  toPlain(scaleEntry(spaced, 100)),
+  { kj: 200, protein: 10, carbs: 20, fat: 5 },
+  'handles spaces in the unit string'
 );
 
 console.log('scaleEntry tests passed');


### PR DESCRIPTION
## Summary
- fix parsing of unit numbers in diet tracker
- test that scaling works when amount matches a 100g unit
- handle spaces in unit strings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d5f249080832a8885c03cdf0b989b