### PR TITLE
Add more diet tracker tests

### DIFF
--- a/docs/webapps/diet-tracker/app.js
+++ b/docs/webapps/diet-tracker/app.js
@@ -44,6 +44,101 @@ const scaleEntry = (food, amount) => {
   };
 };
 
+// Utility for DOM access when running in the browser
+const $ = id => (typeof document === 'undefined' ? null : document.getElementById(id));
+
+// Rebuild datalist options according to MRU order. Returns sorted names for tests.
+const updateDatalist = () => {
+  const entries = Object.keys(foodDB);
+  entries.sort((a, b) => {
+    const iA = saved.mruFoods.indexOf(a);
+    const iB = saved.mruFoods.indexOf(b);
+    if (iA !== -1 || iB !== -1) {
+      if (iA === -1) return 1;
+      if (iB === -1) return -1;
+      return iA - iB;
+    }
+    return a.localeCompare(b);
+  });
+  if (typeof document !== 'undefined') {
+    const dl = $('foodOptions');
+    if (dl) {
+      dl.innerHTML = '';
+      entries.forEach(name => {
+        const opt = document.createElement('option');
+        opt.value = name;
+        dl.appendChild(opt);
+      });
+    }
+  }
+  return entries;
+};
+
+// Create sorted history rows and render when DOM is available
+const renderHistoryTable = () => {
+  const rows = Object.entries(history)
+    .sort(([dateA], [dateB]) => dateB.localeCompare(dateA));
+  if (typeof document !== 'undefined') {
+    const tbody = $('historyTable')?.querySelector('tbody');
+    if (tbody) {
+      tbody.innerHTML = '';
+      rows.forEach(([date, data]) => {
+        const t = data.totals;
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${date}</td><td>${t.kj.toFixed(1)}</td><td>${t.protein.toFixed(1)}</td><td>${t.carbs.toFixed(1)}</td><td>${t.fat.toFixed(1)}</td>`;
+        tbody.appendChild(tr);
+      });
+    }
+  }
+  return rows;
+};
+
+const renderTotals = () => {
+  if (typeof document !== 'undefined') {
+    $('totalKj').textContent = totals.kj.toFixed(1);
+    $('totalProtein').textContent = totals.protein.toFixed(1);
+    $('totalCarbs').textContent = totals.carbs.toFixed(1);
+    $('totalFat').textContent = totals.fat.toFixed(1);
+  }
+};
+
+const renderDiaryTable = () => {
+  if (typeof document !== 'undefined') {
+    const tbody = $('diaryTable').querySelector('tbody');
+    tbody.innerHTML='';
+    diaryEntries.forEach((e, i)=>{
+      const tr=document.createElement('tr');
+      tr.innerHTML = `<td>${e.food}</td><td>${e.amount}</td><td>${e.kj.toFixed(1)}</td><td>${e.protein.toFixed(1)}</td><td>${e.carbs.toFixed(1)}</td><td>${e.fat.toFixed(1)}</td><td><button class="del-btn" data-index="${i}">X</button></td>`;
+      tbody.appendChild(tr);
+    });
+  }
+};
+
+const loadDiary = (date) => {
+  const data = history[date];
+  diaryEntries = data ? [...data.entries] : [];
+  totals = computeTotals(diaryEntries);
+  renderDiaryTable();
+  renderTotals();
+  return { diaryEntries, totals };
+};
+
+const exportData = () => (typeof localStorage === 'undefined' ? '' : (localStorage.getItem('myappdata') || ''));
+
+const importData = text => {
+  if (!text) throw new Error('No data to import');
+  let parsedFull;
+  try {
+    parsedFull = JSON.parse(text);
+  } catch (e) {
+    throw new Error('Invalid JSON format');
+  }
+  const newData = parsedFull[APP_KEY] || {};
+  const currentFull = JSON.parse(localStorage.getItem('myappdata') || '{}');
+  currentFull[APP_KEY] = newData;
+  localStorage.setItem('myappdata', JSON.stringify(currentFull));
+};
+
 if (typeof document !== 'undefined') {
   // Use local timezone to get correct date
   const now = new Date();
@@ -67,7 +162,17 @@ if (typeof document !== 'undefined') {
     }, 2000);
   };
 
-  window.DietTrackerExports = {computeTotals, updateMru, persist, scaleEntry};
+  window.DietTrackerExports = {
+    computeTotals,
+    updateMru,
+    persist,
+    scaleEntry,
+    updateDatalist,
+    renderHistoryTable,
+    loadDiary,
+    exportData,
+    importData
+  };
 
   const loadDiary = (date) => {
     const data = history[date];
@@ -252,31 +357,39 @@ if (typeof document !== 'undefined') {
   loadDiary(todayDate);
   // Data export button
   $('exportBtn')?.addEventListener('click', () => {
-    const data = localStorage.getItem('myappdata') || '';
+    const data = exportData();
     $('dataBox').value = data;
     showNotification('Data exported to text box');
   });
   // Data import button
   $('importBtn')?.addEventListener('click', () => {
     const text = $('dataBox').value.trim();
-    if (!text) { showNotification('No data to import'); return; }
-    let parsedFull;
     try {
-      parsedFull = JSON.parse(text);
+      importData(text);
     } catch(e) {
-      showNotification('Invalid JSON format');
+      showNotification(e.message);
       return;
     }
-    const newData = parsedFull[APP_KEY] || {};
-    // merge into existing storage
-    const currentFull = JSON.parse(localStorage.getItem('myappdata') || '{}');
-    currentFull[APP_KEY] = newData;
-    localStorage.setItem('myappdata', JSON.stringify(currentFull));
     showNotification('Data imported successfully! Reloading...');
     location.reload();
   });
 }
 
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { computeTotals, updateMru, persist, scaleEntry, foodDB, history, saved, myappdata: globalThis.myappdata, localStorage: globalThis.localStorage };
+  module.exports = {
+    computeTotals,
+    updateMru,
+    persist,
+    scaleEntry,
+    loadDiary,
+    updateDatalist,
+    renderHistoryTable,
+    exportData,
+    importData,
+    foodDB,
+    history,
+    saved,
+    myappdata: globalThis.myappdata,
+    localStorage: globalThis.localStorage
+  };
 }

--- a/docs/webapps/diet-tracker/tests/history.test.js
+++ b/docs/webapps/diet-tracker/tests/history.test.js
@@ -1,0 +1,11 @@
+const assert = require('assert');
+const loadExports = require('./helpers');
+const { history, renderHistoryTable } = loadExports();
+Object.assign(history, {
+  '2025-01-02': { totals:{kj:1,protein:1,carbs:1,fat:1}, entries:[] },
+  '2025-01-03': { totals:{kj:2,protein:2,carbs:2,fat:2}, entries:[] },
+  '2025-01-01': { totals:{kj:0,protein:0,carbs:0,fat:0}, entries:[] }
+});
+const rows = renderHistoryTable();
+assert.deepStrictEqual(rows.map(r => r[0]), ['2025-01-03','2025-01-02','2025-01-01']);
+console.log('history sorting tests passed');

--- a/docs/webapps/diet-tracker/tests/importExport.test.js
+++ b/docs/webapps/diet-tracker/tests/importExport.test.js
@@ -1,0 +1,11 @@
+const assert = require('assert');
+const loadExports = require('./helpers');
+const { exportData, importData, localStorage, myappdata } = loadExports();
+myappdata.dietTracker = { foodDB:{}, history:{}, mruFoods:[] };
+localStorage.setItem('myappdata', JSON.stringify(myappdata));
+const exp = exportData();
+assert.strictEqual(exp, JSON.stringify(myappdata));
+const newData = { dietTracker: { foodDB:{apple:{kj:1}}, history:{}, mruFoods:[] } };
+importData(JSON.stringify(newData));
+assert.deepStrictEqual(JSON.parse(localStorage.getItem('myappdata')), newData);
+console.log('import/export tests passed');

--- a/docs/webapps/diet-tracker/tests/loadDiary.test.js
+++ b/docs/webapps/diet-tracker/tests/loadDiary.test.js
@@ -1,0 +1,12 @@
+const assert = require('assert');
+const loadExports = require('./helpers');
+const { history, loadDiary } = loadExports();
+history['2025-07-08'] = {
+  entries: [{food:'apple',amount:100,kj:100,protein:10,carbs:20,fat:5}],
+  totals: {kj:100, protein:10, carbs:20, fat:5}
+};
+const result = loadDiary('2025-07-08');
+assert.strictEqual(result.totals.kj, 100);
+assert.strictEqual(result.diaryEntries.length, 1);
+console.log('loadDiary tests passed');
+

--- a/docs/webapps/diet-tracker/tests/run.js
+++ b/docs/webapps/diet-tracker/tests/run.js
@@ -2,4 +2,8 @@ require('./computeTotals.test');
 require('./mru.test');
 require('./persist.test');
 require('./scaleEntry.test');
+require('./history.test');
+require('./updateDatalist.test');
+require('./loadDiary.test');
+require('./importExport.test');
 console.log('All tests passed');

--- a/docs/webapps/diet-tracker/tests/updateDatalist.test.js
+++ b/docs/webapps/diet-tracker/tests/updateDatalist.test.js
@@ -1,0 +1,8 @@
+const assert = require('assert');
+const loadExports = require('./helpers');
+const { saved, foodDB, updateDatalist } = loadExports();
+Object.assign(foodDB, { apple:{}, banana:{}, carrot:{} });
+saved.mruFoods = ['banana','apple'];
+const order = updateDatalist();
+assert.deepStrictEqual(order.slice(0,2), ['banana','apple']);
+console.log('updateDatalist tests passed');


### PR DESCRIPTION
## Summary
- expose more helper functions in diet tracker
- export/import helpers for data
- add tests for history sorting, datalist MRU order, diary loading and import/export
- hook new tests into test runner

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d5e54eb24832a9f77380f700fe8b9