### PR TITLE
Fix comma decimal units in diet tracker

### DIFF
--- a/docs/webapps/diet-tracker/app.js
+++ b/docs/webapps/diet-tracker/app.js
@@ -30,12 +30,20 @@ const persist = () => {
 const parseUnitNumber = unit => {
   if (unit == null) return 1;
   const m = String(unit).trim().match(/[0-9.,]+/);
-  if (m) {
-    const cleaned = m[0].replace(/,/g, '');
-    const num = parseFloat(cleaned);
-    if (!isNaN(num)) return num;
+  if (!m) return 1;
+  let str = m[0];
+  if (str.includes(',') && !str.includes('.')) {
+    const parts = str.split(',');
+    if (parts.length === 2 && parts[1].length !== 3) {
+      str = parts[0] + '.' + parts[1];
+    } else {
+      str = str.replace(/,/g, '');
+    }
+  } else {
+    str = str.replace(/,/g, '');
   }
-  return 1;
+  const num = parseFloat(str);
+  return isNaN(num) ? 1 : num;
 };
 
 const scaleEntry = (food, amount) => {
@@ -347,6 +355,7 @@ if (typeof module !== 'undefined' && module.exports) {
     renderHistoryTable,
     exportData,
     importData,
+    parseUnitNumber,
     foodDB,
     history,
     saved,

--- a/docs/webapps/diet-tracker/tests/parseUnitNumber.test.js
+++ b/docs/webapps/diet-tracker/tests/parseUnitNumber.test.js
@@ -1,0 +1,8 @@
+const assert = require('assert');
+const loadExports = require('./helpers');
+const { parseUnitNumber } = loadExports();
+
+assert.strictEqual(parseUnitNumber('100g'), 100);
+assert.strictEqual(parseUnitNumber('1,5 cup'), 1.5);
+assert.strictEqual(parseUnitNumber('1,000 g'), 1000);
+console.log('parseUnitNumber tests passed');

--- a/docs/webapps/diet-tracker/tests/run.js
+++ b/docs/webapps/diet-tracker/tests/run.js
@@ -2,6 +2,7 @@ require('./computeTotals.test');
 require('./mru.test');
 require('./persist.test');
 require('./scaleEntry.test');
+require('./parseUnitNumber.test');
 require('./history.test');
 require('./updateDatalist.test');
 require('./loadDiary.test');


### PR DESCRIPTION
## Summary
- handle comma decimals and thousand separators in `parseUnitNumber`
- export `parseUnitNumber` for testing
- add new unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d6de0cb24832a8114052cf971fa54