### PR TITLE
Fix unit handling in diet tracker

### DIFF
--- a/docs/webapps/diet-tracker/AGENTS.md
+++ b/docs/webapps/diet-tracker/AGENTS.md
@@ -6,3 +6,4 @@
 - `scaleEntry` relies on a helper called `parseUnitNumber` to extract the first
   numeric value from a food's unit string. This keeps amounts like `"1 cup (250g)"`
   scaled using the cup measure, not the grams.
+- If a food entry lacks a `unit`, it now defaults to `'100g'` on app load (2025-07).

--- a/docs/webapps/diet-tracker/app.js
+++ b/docs/webapps/diet-tracker/app.js
@@ -8,6 +8,10 @@ const foodDB = saved.foodDB || {};
 const history = saved.history || {};
 saved.foodDB = foodDB;
 saved.history = history;
+// Ensure all foods have a unit; default to '100g' if missing
+Object.values(foodDB).forEach(f => {
+  if (!f.unit) f.unit = '100g';
+});
 
 let diaryEntries = [];
 let totals = {kj:0, protein:0, carbs:0, fat:0};

--- a/docs/webapps/diet-tracker/tests/defaultUnit.test.js
+++ b/docs/webapps/diet-tracker/tests/defaultUnit.test.js
@@ -1,0 +1,15 @@
+const assert = require('assert');
+const loadExports = require('./helpers');
+
+const initialData = {
+  dietTracker: {
+    foodDB: {
+      'Sour Cream per 100g': { kj: 1400, protein: 1.9, carbs: 2.2, fat: 36 }
+    },
+    history: {}
+  }
+};
+
+const { foodDB } = loadExports(initialData);
+assert.strictEqual(foodDB['Sour Cream per 100g'].unit, '100g');
+console.log('default unit tests passed');

--- a/docs/webapps/diet-tracker/tests/helpers.js
+++ b/docs/webapps/diet-tracker/tests/helpers.js
@@ -1,10 +1,10 @@
-module.exports = function loadExports() {
+module.exports = function loadExports(initialData = {}) {
   delete require.cache[require.resolve('../app.js')];
   global.localStorage = {
     _data: {},
     setItem(k, v) { this._data[k] = v; },
     getItem(k) { return this._data[k]; }
   };
-  global.myappdata = {};
+  global.myappdata = initialData;
   return require('../app.js');
 };

--- a/docs/webapps/diet-tracker/tests/run.js
+++ b/docs/webapps/diet-tracker/tests/run.js
@@ -3,6 +3,7 @@ require('./mru.test');
 require('./persist.test');
 require('./scaleEntry.test');
 require('./parseUnitNumber.test');
+require('./defaultUnit.test');
 require('./history.test');
 require('./updateDatalist.test');
 require('./loadDiary.test');


### PR DESCRIPTION
## Summary
- ensure every food entry has a unit when loading saved data
- add regression test for default unit

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d7047b690832ab944aed19ababa6f