### PR TITLE
Add jsdom DOM test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,3 +7,5 @@
 - Basic unit tests for the diet tracker live under
   `docs/webapps/diet-tracker/tests/` and can be run with `npm test` (2025-07).
 
+- Network access allowed; npm packages like jsdom can be installed (2025-07).
+  DOM-based tests now use jsdom to load the diet tracker page (2025-07).

--- a/docs/webapps/diet-tracker/AGENTS.md
+++ b/docs/webapps/diet-tracker/AGENTS.md
@@ -2,6 +2,7 @@
 - JS and CSS may be split out of `index.html` to aid testing and maintenance. The current files are `app.js` and `style.css` (2025-07).
 - Update `use-cases.md` when major features change.
 - Unit tests for this app live in the `tests/` subfolder and run with `npm test`.
+  Some tests use jsdom to simulate button clicks (2025-07).
 - Helper functions are exported from `app.js` using `module.exports`; tests require this module directly.
 - `scaleEntry` relies on a helper called `parseUnitNumber` to extract the first
   numeric value from a food's unit string. This keeps amounts like `"1 cup (250g)"`

--- a/docs/webapps/diet-tracker/tests/domButton.test.js
+++ b/docs/webapps/diet-tracker/tests/domButton.test.js
@@ -1,0 +1,30 @@
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const { JSDOM } = require('jsdom');
+
+module.exports = function() {
+  const html = fs.readFileSync(path.join(__dirname, '../index.html'), 'utf8');
+  const dom = new JSDOM(html, {
+    runScripts: 'outside-only',
+    url: 'http://localhost/'
+  });
+  dom.window.localStorage.setItem('myappdata', JSON.stringify({ dietTracker: { foodDB: {}, history: {}, mruFoods: [] } }));
+  const script = fs.readFileSync(path.join(__dirname, '../app.js'), 'utf8');
+  dom.window.eval(script);
+
+  const doc = dom.window.document;
+  doc.getElementById('foodName').value = 'banana';
+  doc.getElementById('unit').value = '100g';
+  doc.getElementById('kj').value = '400';
+  doc.getElementById('protein').value = '5';
+  doc.getElementById('carbs').value = '20';
+  doc.getElementById('fat').value = '1';
+  doc.getElementById('addFoodBtn').dispatchEvent(new dom.window.Event('click', { bubbles: true }));
+
+  const stored = JSON.parse(dom.window.localStorage.getItem('myappdata'));
+  assert(stored.dietTracker.foodDB.banana);
+  assert.strictEqual(stored.dietTracker.foodDB.banana.unit, '100g');
+  assert.strictEqual(doc.querySelector('#foodTable tbody').children.length, 1);
+  console.log('DOM button test passed');
+};

--- a/docs/webapps/diet-tracker/tests/run.js
+++ b/docs/webapps/diet-tracker/tests/run.js
@@ -11,4 +11,5 @@ require('./renderTotals.test');
 require('./renderDiaryTable.test');
 require('./escapeFoodName.test');
 require('./importExport.test');
+require('./domButton.test')();
 console.log('All tests passed');


### PR DESCRIPTION
## Summary
- note DOM-based test in AGENTS
- mention jsdom use in diet-tracker AGENTS
- add domButton.test.js to simulate Add Food button with jsdom
- include domButton.test in test runner

## Testing
- `npm install jsdom --no-save`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d6be16008832a932d81b7cd9b77ac