### PR TITLE
Add merge queue workflow for diet tracker tests

### DIFF
--- a/.github/merge.yml
+++ b/.github/merge.yml
@@ -1,0 +1,7 @@
+merge_queue:
+  # Run diet tracker tests before merging
+  tasks:
+    - name: diet-tracker-tests
+      run: |
+        npm ci
+        npm test

--- a/.github/workflows/diet-tracker-test.yml
+++ b/.github/workflows/diet-tracker-test.yml
@@ -1,0 +1,20 @@
+name: Diet Tracker Merge Tests
+
+on:
+  merge_group:
+    types: [checks_requested]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - name: Install dependencies
+        run: npm ci
+      - name: Run diet tracker tests
+        run: npm test


### PR DESCRIPTION
## Summary
- configure merge queue tasks in `.github/merge.yml`
- add workflow to run diet tracker tests on `merge_group`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d7e56a8b4832a89d49dc5b74f8b2a