### PR TITLE
Add new jsdom DOM tests for Diet Tracker

### DIFF
--- a/docs/webapps/diet-tracker/tests/domDiary.test.js
+++ b/docs/webapps/diet-tracker/tests/domDiary.test.js
@@ -1,0 +1,36 @@
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const { JSDOM } = require('jsdom');
+
+module.exports = function() {
+  const html = fs.readFileSync(path.join(__dirname, '../index.html'), 'utf8');
+  const dom = new JSDOM(html, {
+    runScripts: 'outside-only',
+    url: 'http://localhost/'
+  });
+  // preload localStorage with a food
+  const data = {
+    dietTracker: {
+      foodDB: {
+        banana: { unit: '100g', kj: 100, protein: 1, carbs: 20, fat: 3 }
+      },
+      history: {},
+      mruFoods: []
+    }
+  };
+  dom.window.localStorage.setItem('myappdata', JSON.stringify(data));
+  const script = fs.readFileSync(path.join(__dirname, '../app.js'), 'utf8');
+  dom.window.eval(script);
+
+  const doc = dom.window.document;
+  doc.getElementById('diaryFood').value = 'banana';
+  doc.getElementById('amount').value = '150';
+  doc.getElementById('addDiaryBtn').dispatchEvent(new dom.window.Event('click', { bubbles: true }));
+
+  const rowCount = doc.querySelector('#diaryTable tbody').children.length;
+  assert.strictEqual(rowCount, 1);
+  assert.strictEqual(doc.getElementById('totalKj').textContent, '150.0');
+  assert.strictEqual(doc.getElementById('totalCarbs').textContent, '30.0');
+  console.log('DOM diary add test passed');
+};

--- a/docs/webapps/diet-tracker/tests/domSaveDay.test.js
+++ b/docs/webapps/diet-tracker/tests/domSaveDay.test.js
@@ -1,0 +1,36 @@
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const { JSDOM } = require('jsdom');
+
+module.exports = function() {
+  const html = fs.readFileSync(path.join(__dirname, '../index.html'), 'utf8');
+  const dom = new JSDOM(html, {
+    runScripts: 'outside-only',
+    url: 'http://localhost/'
+  });
+  const data = {
+    dietTracker: {
+      foodDB: {
+        apple: { unit: '100g', kj: 200, protein: 2, carbs: 10, fat: 1 }
+      },
+      history: {},
+      mruFoods: []
+    }
+  };
+  dom.window.localStorage.setItem('myappdata', JSON.stringify(data));
+  const script = fs.readFileSync(path.join(__dirname, '../app.js'), 'utf8');
+  dom.window.eval(script);
+
+  const doc = dom.window.document;
+  const date = doc.getElementById('diaryDate').value;
+  doc.getElementById('diaryFood').value = 'apple';
+  doc.getElementById('amount').value = '100';
+  doc.getElementById('addDiaryBtn').dispatchEvent(new dom.window.Event('click', { bubbles: true }));
+  doc.getElementById('saveDayBtn').dispatchEvent(new dom.window.Event('click', { bubbles: true }));
+
+  const stored = JSON.parse(dom.window.localStorage.getItem('myappdata'));
+  assert(stored.dietTracker.history[date]);
+  assert.strictEqual(doc.querySelector('#historyTable tbody').children.length, 1);
+  console.log('DOM save day test passed');
+};

--- a/docs/webapps/diet-tracker/tests/run.js
+++ b/docs/webapps/diet-tracker/tests/run.js
@@ -12,4 +12,6 @@ require('./renderDiaryTable.test');
 require('./escapeFoodName.test');
 require('./importExport.test');
 require('./domButton.test')();
+require('./domDiary.test')();
+require('./domSaveDay.test')();
 console.log('All tests passed');

--- a/package.json
+++ b/package.json
@@ -12,5 +12,8 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs"
+  "type": "commonjs",
+  "dependencies": {
+    "jsdom": "^26.1.0"
+  }
 }


### PR DESCRIPTION
## Summary
- add jsdom dependency
- add DOM tests for diary add and save day
- run new tests in test runner

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d9731cab8832ab4ce317eb1290369