### PR TITLE
Add unit tests for exercise tracker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,8 +5,10 @@
 - Microeconomics topics have individual HTML pages linked from the index (2025-06).
 - The `docs/webapps/` folder holds small apps. The diet tracker may include separate JS and CSS files and is linked from the site index (2025-06). The diet tracker currently uses `app.js` and `style.css` (2025-07).
 - The `exercise-tracker` app lives under `docs/webapps/exercise-tracker/` as a standalone HTML page (2025-07).
-- Basic unit tests for the diet tracker live under
-  `docs/webapps/diet-tracker/tests/` and can be run with `npm test` (2025-07).
+ - Basic unit tests for the diet tracker live under
+   `docs/webapps/diet-tracker/tests/` and can be run with `npm test` (2025-07).
+ - The exercise tracker now also has tests under
+   `docs/webapps/exercise-tracker/tests/` which run as part of `npm test` (2025-07).
 
 - A GitHub workflow `Diet Tracker Manual Tests` lets you trigger these
   tests from the Actions tab; they don't run automatically on merge yet (2025-07).

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ npm install
 
 to update `package-lock.json` as needed.
 
-To execute all unit tests for the diet tracker, run:
+To execute all unit tests for the diet tracker and the exercise tracker, run:
 
 ```bash
 npm test

--- a/docs/webapps/exercise-tracker/tests/formatDate.test.js
+++ b/docs/webapps/exercise-tracker/tests/formatDate.test.js
@@ -1,0 +1,23 @@
+const assert = require('assert');
+const loadDom = require('./helpers');
+
+const dom = loadDom();
+const { formatDateForDisplay, getTodayDateString } = dom.window;
+
+// Test getTodayDateString format YYYY-MM-DD
+const today = new Date();
+const expected = today.toISOString().split('T')[0];
+assert.strictEqual(getTodayDateString(), expected);
+
+// Test formatting of a specific date
+assert.strictEqual(
+  formatDateForDisplay('2025-07-04'),
+  new Date(2025, 6, 4).toLocaleDateString('en-US', {
+    weekday: 'long',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric'
+  })
+);
+
+console.log('format date tests passed');

--- a/docs/webapps/exercise-tracker/tests/helpers.js
+++ b/docs/webapps/exercise-tracker/tests/helpers.js
@@ -1,0 +1,15 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+module.exports = function loadDom(initialData = '{}') {
+  const html = fs.readFileSync(path.join(__dirname, '../index.html'), 'utf8');
+  const dom = new JSDOM(html, { runScripts: 'outside-only', url: 'http://localhost/' });
+  const scripts = dom.window.document.querySelectorAll('script');
+  if (scripts.length > 1) {
+    dom.window.eval(scripts[1].textContent);
+  }
+  dom.window.localStorage.setItem('exerciseLogs', initialData);
+  dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
+  return dom;
+};

--- a/docs/webapps/exercise-tracker/tests/importExport.test.js
+++ b/docs/webapps/exercise-tracker/tests/importExport.test.js
@@ -1,0 +1,14 @@
+const assert = require('assert');
+const loadDom = require('./helpers');
+
+const dom = loadDom('{}');
+const { document, importFromText, exportToTextbox } = dom.window;
+
+document.getElementById('importData').value = '{"2025-07-11":{"log":"Run","exercised":true}}';
+importFromText();
+assert.strictEqual(dom.window.localStorage.getItem('exerciseLogs'), '{"2025-07-11":{"log":"Run","exercised":true}}');
+
+exportToTextbox();
+assert.strictEqual(document.getElementById('importData').value, '{"2025-07-11":{"log":"Run","exercised":true}}');
+
+console.log('import/export tests passed');

--- a/docs/webapps/exercise-tracker/tests/run.js
+++ b/docs/webapps/exercise-tracker/tests/run.js
@@ -1,0 +1,4 @@
+require('./formatDate.test');
+require('./saveEntry.test');
+require('./importExport.test');
+console.log('Exercise tracker tests passed');

--- a/docs/webapps/exercise-tracker/tests/saveEntry.test.js
+++ b/docs/webapps/exercise-tracker/tests/saveEntry.test.js
@@ -1,0 +1,19 @@
+const assert = require('assert');
+const loadDom = require('./helpers');
+
+const dom = loadDom('{}');
+const { document, saveEntry } = dom.window;
+
+document.getElementById('date').value = '2025-07-10';
+document.getElementById('log').value = 'Test workout';
+document.getElementById('exercised').checked = true;
+
+saveEntry();
+
+const stored = JSON.parse(dom.window.localStorage.getItem('exerciseLogs'));
+assert.deepStrictEqual(stored['2025-07-10'], { log: 'Test workout', exercised: true });
+
+const entries = document.querySelectorAll('#output .log-entry');
+assert.strictEqual(entries.length, 1);
+
+console.log('save entry DOM test passed');

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "doc": "docs"
   },
   "scripts": {
-    "test": "node docs/webapps/diet-tracker/tests/run.js"
+    "test": "node docs/webapps/diet-tracker/tests/run.js && node docs/webapps/exercise-tracker/tests/run.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- create tests for the exercise tracker similar to the diet tracker
- update package.json to run both test suites
- document new test location in AGENTS and README

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686eb44af570832aadcde7e1ce606b1a