### PR TITLE
Fix exercise tracker averages

### DIFF
--- a/docs/webapps/exercise-tracker/index.html
+++ b/docs/webapps/exercise-tracker/index.html
@@ -697,6 +697,34 @@
       }
     }
 
+    // Compute moving averages using historical data
+    function avgWithHistory(dateArr, rawData, n) {
+      const result = [];
+      for (const dateStr of dateArr) {
+        let sum = 0;
+        for (let offset = 0; offset < n; offset++) {
+          const parts = dateStr.split('-');
+          const d = new Date(
+            parseInt(parts[0]),
+            parseInt(parts[1]) - 1,
+            parseInt(parts[2])
+          );
+          d.setDate(d.getDate() - offset);
+          const year = d.getFullYear();
+          const month = String(d.getMonth() + 1).padStart(2, '0');
+          const day = String(d.getDate()).padStart(2, '0');
+          const key = `${year}-${month}-${day}`;
+          const entry = rawData[key];
+          if (entry && typeof entry === 'object' && entry.exercised) {
+            sum += 1;
+          }
+        }
+        result.push(sum / n);
+      }
+      return result;
+    }
+    window.avgWithHistory = avgWithHistory;
+
     function drawChart() {
       if (typeof Chart === 'undefined') {
         console.error('Chart.js failed to load.');
@@ -739,20 +767,6 @@
 
       const data = parsed.map(e => e.exercised);
 
-      const avg = (arr, n) => {
-        const result = [];
-        for (let i = 0; i < arr.length; i++) {
-          let sum = 0;
-          let count = 0;
-          for (let j = i - n + 1; j <= i; j++) {
-            sum += j >= 0 ? arr[j] : 0;
-            count++;
-          }
-          result.push(sum / count);
-        }
-        return result;
-      };
-
       if (window.exerciseChart) {
         window.exerciseChart.destroy();
       }
@@ -778,7 +792,7 @@
             },
             {
               label: '7-Day Average',
-              data: avg(data, 7),
+              data: avgWithHistory(dates, raw, 7),
               borderColor: '#764ba2',
               borderDash: [5, 5],
               fill: false,
@@ -786,7 +800,7 @@
             },
             {
               label: '14-Day Average',
-              data: avg(data, 14),
+              data: avgWithHistory(dates, raw, 14),
               borderColor: '#e53e3e',
               borderDash: [8, 4],
               fill: false,

--- a/docs/webapps/exercise-tracker/tests/avgWithHistory.test.js
+++ b/docs/webapps/exercise-tracker/tests/avgWithHistory.test.js
@@ -1,0 +1,35 @@
+const assert = require('assert');
+const loadDom = require('./helpers');
+
+// Create 21 consecutive workout days starting 2025-06-20
+const data = {};
+const start = new Date(2025, 5, 20); // months are 0-indexed
+for (let i = 0; i < 21; i++) {
+  const d = new Date(start);
+  d.setDate(start.getDate() + i);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  data[`${y}-${m}-${day}`] = { exercised: true };
+}
+
+const dom = loadDom(JSON.stringify(data));
+const { avgWithHistory } = dom.window;
+
+// Dates shown in chart from 2025-06-27 to 2025-07-10
+const dates = [];
+const showStart = new Date(2025, 5, 27);
+for (let i = 0; i < 14; i++) {
+  const d = new Date(showStart);
+  d.setDate(showStart.getDate() + i);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  dates.push(`${y}-${m}-${day}`);
+}
+
+const avgs = avgWithHistory(dates, data, 7);
+assert.strictEqual(avgs[0], 1);
+
+console.log('avgWithHistory test passed');
+

--- a/docs/webapps/exercise-tracker/tests/run.js
+++ b/docs/webapps/exercise-tracker/tests/run.js
@@ -1,4 +1,5 @@
 require('./formatDate.test');
 require('./saveEntry.test');
 require('./importExport.test');
+require('./avgWithHistory.test');
 console.log('Exercise tracker tests passed');


### PR DESCRIPTION
## Summary
- compute moving averages using dates prior to chart window
- test moving average logic

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ebd7c16dc832aa461b6adc25dc34d