### PR TITLE
Update exercise tracker to 28-day view

### DIFF
--- a/docs/webapps/exercise-tracker/index.html
+++ b/docs/webapps/exercise-tracker/index.html
@@ -735,7 +735,7 @@
       const dates = [];
       const today = new Date();
       
-      for (let i = 13; i >= 0; i--) {
+      for (let i = 27; i >= 0; i--) {
         const d = new Date(today);
         d.setDate(today.getDate() - i);
         // Use local date formatting to avoid timezone issues
@@ -838,7 +838,7 @@
             },
             title: { 
               display: true, 
-              text: 'Workout Activity - Last 14 Days',
+              text: 'Workout Activity - Last 28 Days',
               font: { size: 16, weight: 'bold' },
               padding: 20
             }


### PR DESCRIPTION
## Summary
- extend the exercise tracker chart to show 28 days

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686ed06770f0832a899c2c933422b459