### PR TITLE
Add JSON food import feature

### DIFF
--- a/docs/webapps/diet-tracker/AGENTS.md
+++ b/docs/webapps/diet-tracker/AGENTS.md
@@ -10,3 +10,4 @@
 - If a food entry lacks a `unit`, it now defaults to `'100g'` on app load (2025-07).
 - The Data tab includes buttons to download or upload JSON files (2025-07).
 - DOM tests cover the download/upload helpers (2025-07).
+- A helper adds foods from JSON pasted into the Data tab (2025-07).

--- a/docs/webapps/diet-tracker/app.js
+++ b/docs/webapps/diet-tracker/app.js
@@ -180,6 +180,32 @@ const importData = text => {
   localStorage.setItem('myappdata', JSON.stringify(currentFull));
 };
 
+const addFoodsFromJson = text => {
+  if (!text) throw new Error('No data to import');
+  let foods;
+  try {
+    foods = JSON.parse(text);
+  } catch (e) {
+    throw new Error('Invalid JSON format');
+  }
+  if (typeof foods !== 'object' || foods === null || Array.isArray(foods)) {
+    throw new Error('Invalid food data');
+  }
+  Object.entries(foods).forEach(([name, info]) => {
+    if (info && typeof info === 'object') {
+      foodDB[name] = {
+        unit: info.unit || '100g',
+        kj: parseFloat(info.kj) || 0,
+        protein: parseFloat(info.protein) || 0,
+        carbs: parseFloat(info.carbs) || 0,
+        fat: parseFloat(info.fat) || 0
+      };
+    }
+  });
+  persist();
+  return Object.keys(foods);
+};
+
 let downloadDataFile = () => {};
 let handleFileUpload = () => Promise.reject(new Error('File API unavailable'));
 
@@ -246,6 +272,7 @@ if (typeof document !== 'undefined') {
     loadDiary,
     exportData,
     importData,
+    addFoodsFromJson,
     downloadDataFile,
     handleFileUpload
   };
@@ -428,6 +455,20 @@ if (typeof document !== 'undefined') {
     showNotification('Data imported successfully! Reloading...');
     location.reload();
   });
+  // Import foods button
+  $('importFoodBtn')?.addEventListener('click', () => {
+    const text = $('dataBox').value.trim();
+    let names;
+    try {
+      names = addFoodsFromJson(text);
+    } catch (e) {
+      showNotification(e.message);
+      return;
+    }
+    renderFoodTable();
+    updateDatalist();
+    showNotification(`Imported ${names.length} foods`);
+  });
   // Download data file
   $('downloadFileBtn')?.addEventListener('click', () => {
     downloadDataFile();
@@ -463,6 +504,7 @@ if (typeof module !== 'undefined' && module.exports) {
     renderHistoryTable,
     exportData,
     importData,
+    addFoodsFromJson,
     downloadDataFile,
     handleFileUpload,
     parseUnitNumber,

--- a/docs/webapps/diet-tracker/index.html
+++ b/docs/webapps/diet-tracker/index.html
@@ -129,6 +129,7 @@
       <div style="display:flex;gap:15px;margin-top:20px;flex-wrap:wrap;">
         <button id="exportBtn" class="btn btn-primary">📤 Export Data</button>
         <button id="importBtn" class="btn btn-success">📥 Import Data</button>
+        <button id="importFoodBtn" class="btn btn-success">🍎 Add Foods</button>
         <button id="downloadFileBtn" class="btn btn-primary">⬇️ Download File</button>
         <button id="uploadFileBtn" class="btn btn-success">⬆️ Upload File</button>
         <input type="file" id="dataFileInput" accept="application/json" style="display:none" />

--- a/docs/webapps/diet-tracker/tests/domImportFoods.test.js
+++ b/docs/webapps/diet-tracker/tests/domImportFoods.test.js
@@ -1,0 +1,22 @@
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const { JSDOM } = require('jsdom');
+
+module.exports = function() {
+  const html = fs.readFileSync(path.join(__dirname, '../index.html'), 'utf8');
+  const dom = new JSDOM(html, { runScripts: 'outside-only', url: 'http://localhost/' });
+  dom.window.localStorage.setItem('myappdata', JSON.stringify({ dietTracker: { foodDB: {}, history: {}, mruFoods: [] } }));
+  const script = fs.readFileSync(path.join(__dirname, '../app.js'), 'utf8');
+  dom.window.eval(script);
+
+  const doc = dom.window.document;
+  doc.getElementById('dataBox').value = JSON.stringify({ pear: { unit: '100g', kj: 50, protein: 1, carbs: 13, fat: 0 } });
+  doc.getElementById('importFoodBtn').dispatchEvent(new dom.window.Event('click', { bubbles: true }));
+
+  const stored = JSON.parse(dom.window.localStorage.getItem('myappdata'));
+  assert(stored.dietTracker.foodDB.pear);
+  assert.strictEqual(doc.querySelector('#foodTable tbody').children.length, 1);
+  console.log('DOM import foods test passed');
+};
+

--- a/docs/webapps/diet-tracker/tests/importFoods.test.js
+++ b/docs/webapps/diet-tracker/tests/importFoods.test.js
@@ -1,0 +1,15 @@
+const assert = require('assert');
+const loadExports = require('./helpers');
+
+const ctx = loadExports({ dietTracker: { foodDB: {}, history: {}, mruFoods: [] } });
+const { foodDB, addFoodsFromJson } = ctx;
+
+addFoodsFromJson(JSON.stringify({
+  banana: { unit: '100g', kj: 300, protein: 2, carbs: 20, fat: 1 },
+  cheese: { kj: 1200, protein: 25, carbs: 2, fat: 30 }
+}));
+
+assert(foodDB.banana);
+assert.strictEqual(foodDB.cheese.unit, '100g');
+console.log('import foods tests passed');
+

--- a/docs/webapps/diet-tracker/tests/run.js
+++ b/docs/webapps/diet-tracker/tests/run.js
@@ -12,10 +12,12 @@ const run = async () => {
   require('./renderDiaryTable.test');
   require('./escapeFoodName.test');
   require('./importExport.test');
+  require('./importFoods.test');
   await require('./domButton.test')();
   await require('./domDiary.test')();
   await require('./domSaveDay.test')();
   await require('./domFileTransfer.test')();
+  await require('./domImportFoods.test')();
   console.log('All tests passed');
 };
 

--- a/docs/webapps/diet-tracker/use-cases.md
+++ b/docs/webapps/diet-tracker/use-cases.md
@@ -5,3 +5,4 @@
 - Review history of saved days and track progress over time.
 - Import or export data to share between devices.
 - Download your data as a JSON file and upload it on another device.
+- Paste JSON food data into the Data tab to quickly add multiple foods.


### PR DESCRIPTION
## Summary
- support adding multiple foods from JSON text
- wire button on Data tab for importing foods
- document new workflow
- test new helper and DOM behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687483c27d00832a9e1b965bf76d4bde